### PR TITLE
Add link to plantcv docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ repo_url: https://github.com/danforthcenter/plantcv-hyperspectral
 theme: readthedocs
 
 pages:
+- 'PlantCV Home': https://plantcv.readthedocs.io
 - Home: index.md
 
 markdown_extensions:


### PR DESCRIPTION
Adds a link at the top of the TOC to link back to the PlantCV documentation homepage.